### PR TITLE
ci: add concurrency, workflow_dispatch, and --dangerously-skip-permissions

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -3,6 +3,11 @@ name: OpenCode Review
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   opencode-review:
@@ -33,6 +38,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           opencode run \
+            --dangerously-skip-permissions \
             --model openrouter/deepseek/deepseek-v4-pro \
             "Review PR #${PR_NUMBER} on this repository.
 


### PR DESCRIPTION
Fixes from the code review on #34:

- Add `--dangerously-skip-permissions` to prevent CI hang on tool calls
- Add `concurrency` group to cancel stale runs on rapid pushes
- Add `workflow_dispatch` trigger for manual re-runs

Note: skipped `anomalyco/opencode/github@latest` action — it's stale (stuck on v1.2.9 from Jan 2026)