### PR TITLE
ci: fix workflow_dispatch bug and clean up permissions

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -3,10 +3,9 @@ name: OpenCode Review
 on:
   pull_request:
     types: [opened, synchronize]
-  workflow_dispatch:
 
 concurrency:
-  group: opencode-review-${{ github.event.pull_request.number || github.run_id }}
+  group: opencode-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -15,7 +14,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes from code review:

- Remove `workflow_dispatch` trigger (breaks without PR number)
- Remove unused `issues: read` permission
- Simplify concurrency group (no fallback needed)